### PR TITLE
fix a logic bug in get_another_stream

### DIFF
--- a/rtcp.py
+++ b/rtcp.py
@@ -50,6 +50,9 @@ def _get_another_stream(num):
 
         if streams[num] is not None:
             return streams[num]
+        elif streams[num] is None and streams[num^1] is None:
+            print('stream CLOSED')
+            return None
         else:
             time.sleep(1)
 


### PR DESCRIPTION
the get_another_stream() function maybe hangs when another coming connection closed too quickly, which will cause forwarding error